### PR TITLE
correct total dependents count

### DIFF
--- a/github_dependents_info/gh_dependents_info.py
+++ b/github_dependents_info/gh_dependents_info.py
@@ -75,9 +75,9 @@ class GithubDependentsInfo:
             # Get total number of dependents from UI
             r = self.requests_retry_session().get(url)
             soup = BeautifulSoup(r.content, "html.parser")
-            svg_item = soup.find("svg", {"class": "octicon-code-square"})
+            svg_item = soup.find("a", {"class": "btn-link selected"})
             if svg_item is not None:
-                a_around_svg = svg_item.parent
+                a_around_svg = svg_item
                 total_dependents = self.get_int(
                     a_around_svg.text.replace("Repositories", "").replace("Repository", "").strip()
                 )


### PR DESCRIPTION
## Description

seems extracting total_dependents from the html page is incorrect, probably because GH has updated the page. this PR solve the issue. 

before

`github-dependents-info --repo nvuillam/github-dependents-info` will output:

```text
WARNING:root:WARNING: Unable to get integer from ""
WARNING:root:WARNING: Unable to get integer from ""
Total: 11
Public: 11 (145 stars)
Private: -11
```

after

`github-dependents-info --repo nvuillam/github-dependents-info` will output:

```text
Total: 12
Public: 11 (145 stars)
Private: 1
```


## Related Issue

not found

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/nvuillam/github-dependents-info/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/nvuillam/github-dependents-info/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
