### PR TITLE
:wrench: Fix Safety API throttling in CI and widen Renovate coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,9 @@ jobs:
           make check-codestyle
 
       - name: Run safety checks
-        if: ${{ env.SAFETY_API_KEY != '' }}
+        # Safety.io throttles concurrent scans (HTTP 429) when every matrix job
+        # calls it at once, so run the scan on a single Python version.
+        if: ${{ env.SAFETY_API_KEY != '' && matrix.python-version == '3.12' }}
         env:
           SAFETY_API_KEY: ${{ env.SAFETY_API_KEY }}
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
   "vulnerabilityAlerts": {
     "minimumReleaseAge": null
   },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on monday"]
+  },
   "packageRules": [
     {
-      "matchPackagePatterns": [".*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
## Why

Two unrelated-looking problems with one theme: CI noise from dependency tooling.

### 1. Safety.io throttling made the build matrix flaky

`make check-safety` ran in **all five** matrix jobs at once. Safety.io rate-limits the concurrent scans and returns:

```
Too many requests. Reason: {"detail":"Request was throttled. Expected available in 27-33 seconds."}
make: *** [Makefile:66: check-safety] Error 66
```

Whichever jobs lost the race failed. This is what was actually breaking #1081 (`actions/checkout` v7) and #1132 (`actions/setup-python` v7) — neither failure had anything to do with the action bump; different Python versions failed on each PR purely on timing.

The scan inspects project files, not the interpreter, so running it once is equivalent. It is now gated to Python 3.12.

### 2. Renovate had no transitive coverage

Renovate only bumped constraints declared in `pyproject.toml`, so every *transitive* package in `poetry.lock` was left to Dependabot — which is why Dependabot opens far more PRs and why merging a Renovate PR closes so few of them.

`lockFileMaintenance` makes Renovate refresh the whole lock file in a single PR.

Also replaces two deprecated options that Renovate warns about: `config:base` → `config:recommended`, and `matchPackagePatterns` → `matchPackageNames`.

## Note

This does **not** fully stop the duplicate PR stream. `requirements.txt` is tracked and Dependabot reads it as a separate pip manifest (e.g. #1147 changes only that file), while Renovate never writes it. Untracking it was considered and deliberately deferred.